### PR TITLE
Partition support

### DIFF
--- a/avro_schemas.go
+++ b/avro_schemas.go
@@ -372,6 +372,7 @@ const (
 
 	// EntryV1SchemaTmpl is a Go text/template template for the Avro schema of a v1 manifest entry.
 	// It expects a map[string]any as the partitions as as the templated object. It calls a custom Type function to determine the Avro type for each partition value.
+	// It also calls a PartitionFieldID function to determine the field-id for each partition value.
 	AvroEntryV1SchemaTmpl = `{
         "type": "record",
         "name": "manifest_entry",
@@ -397,14 +398,14 @@ const (
                                 "type": "record",
                                 "name": "r102",
                                 "fields": [
-									{{ $first := true }}
-                                    {{- range $key, $value := . }}
-									{{ if $first }}
-										{{ $first = false }}
-									{{ else }}
-										,
-									{{ end }}
-                                    {"name": "{{ $key }}", "type": {{ Type $value }}}
+                                    {{- $first := true -}}
+                                    {{- range $key, $value := . -}}
+                                    {{- if $first -}}
+                                       {{ $first = false }}
+                                    {{- else -}}
+                                        ,
+                                    {{- end }}
+                                    {"field-id": {{ PartitionFieldID $key }}, "name": "{{ $key }}", "type": {{ Type $value }}}
                                     {{- end }}
                                 ]
                             },

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -79,7 +79,19 @@ type Catalog interface {
 		removals []string, updates iceberg.Properties) (PropertiesUpdateSummary, error)
 
 	// CreateTable tells the catalog to create a new table with the given schema and properties
-	CreateTable(ctx context.Context, location string, schema *iceberg.Schema, props iceberg.Properties) (table.Table, error)
+	CreateTable(ctx context.Context, location string, schema *iceberg.Schema, props iceberg.Properties, options ...TableOption) (table.Table, error)
+}
+
+type TableOption func(*tableOptions)
+
+type tableOptions struct {
+	partitionSpec iceberg.PartitionSpec
+}
+
+func WithPartitionSpec(spec iceberg.PartitionSpec) TableOption {
+	return func(opts *tableOptions) {
+		opts.partitionSpec = spec
+	}
 }
 
 const (

--- a/catalog/hdfs_test.go
+++ b/catalog/hdfs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/polarsignals/iceberg-go"
+	"github.com/polarsignals/iceberg-go/table"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 )
@@ -24,7 +25,9 @@ func Test_HDFS(t *testing.T) {
 	tbl, err := catalog.CreateTable(ctx, tablePath, iceberg.NewSchema(0), iceberg.Properties{})
 	require.NoError(t, err)
 
-	writer, err := tbl.SnapshotWriter()
+	writer, err := tbl.SnapshotWriter(
+		table.WithMergeSchema(),
+	)
 	require.NoError(t, err)
 
 	type RowType struct{ FirstName, LastName string }

--- a/manifest_builder.go
+++ b/manifest_builder.go
@@ -123,9 +123,9 @@ func WriteManifestV1(w io.Writer, entries []ManifestEntry) error {
 		w,
 		ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte("1"),
-			"schema":         []byte("todo"), // TODO
-			"partition-spec": []byte("todo"), // TODO
-			"avro.codec":     []byte("deflate"),
+			//"schema":         []byte("todo"), // TODO
+			//"partition-spec": []byte("todo"), // TODO
+			"avro.codec": []byte("deflate"),
 		}),
 		ocf.WithCodec(ocf.Deflate),
 	)
@@ -147,10 +147,16 @@ func WriteManifestV1(w io.Writer, entries []ManifestEntry) error {
 // The entries must all share the same partition spec.
 func AvroSchemaFromEntriesV1(entries []ManifestEntry) string {
 	partitions := entries[0].DataFile().Partition() // Pull the first entries partition spec since they are expected to be the same for all entries.
+	partitionFieldID := 1000                        // According to the spec partition field IDs start at 1000. https://iceberg.apache.org/spec/#partition-evolution
 	b := &bytes.Buffer{}
 	if err := template.Must(
 		template.New("EntryV1Schema").
 			Funcs(template.FuncMap{
+				"PartitionFieldID": func(_ any) int {
+					prev := partitionFieldID
+					partitionFieldID++
+					return prev
+				},
 				"Type": func(i any) string {
 					switch t := i.(type) {
 					case string:

--- a/parquet.go
+++ b/parquet.go
@@ -25,7 +25,7 @@ func DataFileFromParquet(path string, size int64, r io.ReaderAt) (DataFile, *Sch
 	bldr := NewDataFileV1Builder(
 		path,
 		ParquetFile,
-		map[string]any{}, // TODO allow partition configuration
+		map[string]any{}, // TODO: At present Parquet writes are assumed to be unpartitioned.
 		f.NumRows(),
 		size,
 	)

--- a/partitions.go
+++ b/partitions.go
@@ -41,7 +41,7 @@ type PartitionField struct {
 	// SourceID is the source column id of the table's schema
 	SourceID int `json:"source-id"`
 	// FieldID is the partition field id across all the table partition specs
-	FieldID int `json:"field-id"`
+	FieldID int `json:"field-id,omitempty"`
 	// Name is the name of the partition field itself
 	Name string `json:"name"`
 	// Transform is the transform used to produce the partition value

--- a/schema.go
+++ b/schema.go
@@ -290,35 +290,16 @@ func (s *Schema) Merge(other *Schema) (*Schema, error) {
 		return s, nil
 	}
 
-	if s == other {
-		return s, nil
-	}
-
 	final := s.fields
+	nextID := len(s.fields)
 	for _, field := range other.fields {
 		if _, ok := s.FindFieldByName(field.Name); !ok {
+			field.ID = nextID
 			final = append(final, field)
+			nextID++
 		}
 	}
 
-	// Sort the fields by name
-	slices.SortFunc(final, func(a, b NestedField) int {
-		switch {
-		case a.Name < b.Name:
-			return -1
-		case a.Name > b.Name:
-			return 1
-		default:
-			return 0
-		}
-	})
-
-	// Fixup field ID's
-	for i, f := range final {
-		f.ID = i
-	}
-
-	// TODO: Fixup identifier field IDs
 	return NewSchemaWithIdentifiers(s.ID+1, []int{}, final...), nil
 }
 


### PR DESCRIPTION
Adds some support for populating the partitions field in the manifest list file. 

The writer doesn't support writing the data into partitions (it assumes parquet writes are unpartitioned), but unpartitioned data can still have the upper/lower bounds recorded in the manifest list. 