### PR TITLE
Updates to partitioning 

### DIFF
--- a/manifest_builder.go
+++ b/manifest_builder.go
@@ -2,6 +2,7 @@ package iceberg
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"text/template"
@@ -117,13 +118,18 @@ func WriteManifestListV1(w io.Writer, files []ManifestFile) error {
 	return nil
 }
 
-func WriteManifestV1(w io.Writer, entries []ManifestEntry) error {
+func WriteManifestV1(w io.Writer, schema *Schema, entries []ManifestEntry) error {
+	b, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schema: %w", err)
+	}
+
 	enc, err := ocf.NewEncoder(
 		AvroSchemaFromEntriesV1(entries),
 		w,
 		ocf.WithMetadata(map[string][]byte{
 			"format-version": []byte("1"),
-			//"schema":         []byte("todo"), // TODO
+			"schema":         b,
 			//"partition-spec": []byte("todo"), // TODO
 			"avro.codec": []byte("deflate"),
 		}),

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -403,7 +403,7 @@ func (m *ManifestTestSuite) writeManifestEntries() {
 	for _, ent := range manifestEntryV1Records {
 		entries = append(entries, ent)
 	}
-	m.Require().NoError(WriteManifestV1(&m.v1ManifestEntries, entries))
+	m.Require().NoError(WriteManifestV1(&m.v1ManifestEntries, NewSchema(0), entries))
 
 	enc, err := ocf.NewEncoder(AvroManifestEntryV2Schema,
 		&m.v2ManifestEntries, ocf.WithMetadata(map[string][]byte{

--- a/schema.go
+++ b/schema.go
@@ -20,6 +20,7 @@ package iceberg
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -291,13 +292,19 @@ func (s *Schema) Merge(other *Schema) (*Schema, error) {
 	}
 
 	final := s.fields
-	nextID := len(s.fields)
 	for _, field := range other.fields {
 		if _, ok := s.FindFieldByName(field.Name); !ok {
-			field.ID = nextID
 			final = append(final, field)
-			nextID++
 		}
+	}
+
+	// Sort the schema by name
+	sort.Slice(final, func(i, j int) bool {
+		return final[i].Name < final[j].Name
+	})
+
+	for i := range final {
+		final[i].ID = i
 	}
 
 	return NewSchemaWithIdentifiers(s.ID+1, []int{}, final...), nil

--- a/table/hdfs.go
+++ b/table/hdfs.go
@@ -45,6 +45,7 @@ func (t *hdfsTable) SnapshotWriter(options ...WriterOption) (SnapshotWriter, err
 		version:    t.version,
 		table:      t,
 		schema:     t.metadata.CurrentSchema(),
+		spec:       t.metadata.PartitionSpec(),
 	}
 
 	for _, options := range options {
@@ -62,6 +63,7 @@ type hdfsSnapshotWriter struct {
 	options    writerOptions
 
 	schema  *iceberg.Schema
+	spec    iceberg.PartitionSpec
 	entries []iceberg.ManifestEntry
 }
 
@@ -96,27 +98,30 @@ func (s *hdfsSnapshotWriter) Append(ctx context.Context, r io.Reader) error {
 		if s.schema != nil && !s.schema.Equals(schema) {
 			return fmt.Errorf("schema mismatch: %v != %v", s.schema, schema)
 		}
-	} else {
+	}
 
-		// Merge the schema with the table schema
-		if s.schema == nil {
-			s.schema, err = s.table.Metadata().CurrentSchema().Merge(schema)
-			if err != nil {
-				return err
+	s.schema = schema
+
+	// Update the partition spec if the schema has changed so that the spec ID's match the new field IDs
+	if s.schema.ID != s.table.Metadata().CurrentSchema().ID {
+		spec := s.table.Metadata().PartitionSpec()
+		if !spec.IsUnpartitioned() {
+			updatedFields := make([]iceberg.PartitionField, 0, spec.NumFields())
+			for i := 0; i < spec.NumFields(); i++ {
+				field := spec.Field(i)
+				schemaField, ok := s.schema.FindFieldByName(field.Name)
+				if !ok {
+					return fmt.Errorf("partition field %s not found in schema", field.Name)
+				}
+
+				updatedFields = append(updatedFields, iceberg.PartitionField{
+					SourceID:  schemaField.ID,
+					Name:      field.Name,
+					Transform: field.Transform,
+				})
 			}
-		} else {
-			s.schema, err = s.schema.Merge(schema)
-			if err != nil {
-				return err
-			}
+			s.spec = iceberg.NewPartitionSpec(updatedFields...)
 		}
-
-		// TODO(thor)Update the partition spec if the schema has changed so that the spec ID's match the new field IDs
-		if s.schema.ID != s.table.Metadata().CurrentSchema().ID {
-			spec := s.table.Metadata().PartitionSpec()
-			fmt.Println("Updating partition spec", spec)
-		}
-
 	}
 
 	s.entries = append(s.entries, entry)
@@ -174,8 +179,8 @@ func (s *hdfsSnapshotWriter) Close(ctx context.Context) error {
 		ExistingFiles(int32(len(manifest) - len(s.entries)))
 
 	// Add partition information if the table is partitioned
-	if spec := s.table.Metadata().PartitionSpec(); !spec.IsUnpartitioned() {
-		bldr.Partitions(summarizeFields(spec, s.entries))
+	if !s.spec.IsUnpartitioned() {
+		bldr.Partitions(summarizeFields(s.spec, s.entries))
 	}
 
 	newmanifest := bldr.Build()
@@ -264,7 +269,7 @@ func (s *hdfsSnapshotWriter) addSnapshot(ctx context.Context, t Table, snapshot 
 		WithCurrentSchemaID(schema.ID).
 		WithCurrentSnapshotID(snapshot.SnapshotID).
 		WithSnapshots(append(snapshots, snapshot)).
-		WithPartitionSpecs([]iceberg.PartitionSpec{spec}).
+		WithPartitionSpecs([]iceberg.PartitionSpec{s.spec}).
 		WithDefaultSpecID((&spec).ID()).
 		Build(), nil
 }

--- a/table/hdfs.go
+++ b/table/hdfs.go
@@ -86,7 +86,7 @@ func (s *hdfsSnapshotWriter) Append(ctx context.Context, r io.Reader) error {
 	}
 
 	// Create manifest entry
-	entry, schema, err := iceberg.ManifestEntryV1FromParquet(dataFile, int64(b.Len()), bytes.NewReader(b.Bytes()))
+	entry, schema, err := iceberg.ManifestEntryV1FromParquet(dataFile, int64(b.Len()), s.schema, bytes.NewReader(b.Bytes()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Encode the table schema in the manifests avro metadata
- Go back to sorting the merged table schema
- Adjust the partition spec when the schema changes
- Fix how upper/lower bounds values are encoded in manifest files
- Use the table schema to determine number of rows in the upper/lower bounds array in manifest