### PR TITLE
fetchentries: return table schema

### DIFF
--- a/catalog/hdfs_test.go
+++ b/catalog/hdfs_test.go
@@ -55,7 +55,7 @@ func Test_HDFS(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, manifests, 1)
-	entries, err := manifests[0].FetchEntries(bucket, false)
+	entries, _, err := manifests[0].FetchEntries(bucket, false)
 	require.NoError(t, err)
 
 	require.Len(t, entries, 1)

--- a/table/hdfs.go
+++ b/table/hdfs.go
@@ -151,7 +151,7 @@ func (s *hdfsSnapshotWriter) Close(ctx context.Context) error {
 		// Check the size of the previous manifest file
 		latest := previousManifests[len(previousManifests)-1]
 		if latest.Length() < int64(s.options.manifestSizeBytes) { // Append to the latest manifest
-			previous, err := latest.FetchEntries(s.bucket, false)
+			previous, _, err := latest.FetchEntries(s.bucket, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Have fetch entries return the table schema that they were written with. This allows for correctly filtering the columns