### PR TITLE
table/writer: DeleteDataFile

### DIFF
--- a/table/hdfs.go
+++ b/table/hdfs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 
 	"github.com/thanos-io/objstore"
@@ -33,23 +32,8 @@ func NewHDFSTable(ver int, ident Identifier, meta Metadata, location string, buc
 }
 
 func (t *hdfsTable) SnapshotWriter(options ...WriterOption) (SnapshotWriter, error) {
-	writer := &hdfsSnapshotWriter{
-		snapshotWriter: snapshotWriter{
-			options:    writerOptions{},
-			snapshotID: rand.Int63(),
-			bucket:     t.bucket,
-			version:    t.version,
-			table:      t,
-			schema:     t.metadata.CurrentSchema(),
-			spec:       t.metadata.PartitionSpec(),
-		},
-	}
-
-	for _, options := range options {
-		options(&writer.options)
-	}
-
-	writer.snapshotWriter.commit = writer.commit
+	writer := &hdfsSnapshotWriter{}
+	writer.snapshotWriter = NewSnapshotWriter(writer.commit, t.version, t.bucket, t, options...)
 	return writer, nil
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -135,6 +135,9 @@ type SnapshotWriter interface {
 	// Append accepts a ReaderAt object that should read the Parquet file that is to be added to the snapshot.
 	Append(ctx context.Context, r io.Reader) error
 
+	// DeleteDataFile deletes a data file from the table. The function passed to this method should return true if the file should be deleted.
+	DeleteDataFile(ctx context.Context, del func(file iceberg.DataFile) bool) error
+
 	// Close writes the new snapshot to the table and closes the writer. It is an error to call Append after Close.
 	Close(ctx context.Context) error
 }


### PR DESCRIPTION
Allow deletion of data files from the table.
It removes the datafile from manifests in a new snapshot.

To physically remove the files an orphaned files check would need to be performed as previous snapshots may still contain the data file